### PR TITLE
Add base16-tomorrow and tomorrow-night themes

### DIFF
--- a/native/autumn/src/themes.rs
+++ b/native/autumn/src/themes.rs
@@ -4,7 +4,7 @@
 // Generated automatically by mix task `Mix.Tasks.Autumn.GenerateThemes`.
 // Execute `mix autumn.generate_themes` at the root to update this file.
 //
-// Generated at 2023-10-04 14:50:28.402176Z
+// Generated at 2023-11-12 05:31:51.898767Z
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
@@ -13,7 +13,7 @@ use phf::phf_map;
 
 #[derive(Debug)]
 pub struct Theme {
-    pub scopes: phf::Map<&'static str, (&'static str, &'static str)>,
+    pub scopes: phf::Map<&'static str, (&'static str, &'static str)>
 }
 
 impl Theme {
@@ -706,6 +706,41 @@ static THEMES: phf::Map<&'static str, Theme> = phf_map! {
           "comment.line" => ("comment line", "color: #6272A4;"),
           "markup.bold" => ("markup bold", "font-weight: bold; color: #ffb86c;"),
           "label" => ("label", "color: #8be9fd;"),
+          "markup.strikethrough" => ("markup strikethrough", ""),
+        },
+    },
+    "base16_tomorrow_night" => Theme {
+        scopes: phf_map! {
+          "debug" => ("debug", "color: #969896;"),
+          "constant.numeric" => ("constant numeric", "color: #de935f;"),
+          "function" => ("function", "color: #81a2be;"),
+          "variable.other.member" => ("variable other member", "color: #b5bd68;"),
+          "markup.list" => ("markup list", "color: #cc6666;"),
+          "markup.quote" => ("markup quote", "color: #8abeb7;"),
+          "keyword" => ("keyword", "color: #b294bb;"),
+          "diff.delta" => ("diff delta", "color: #de935f;"),
+          "string" => ("string", "color: #b5bd68;"),
+          "markup.link.url" => ("markup link url", "text-decoration: underline; color: #de935f;"),
+          "constant.character.escape" => ("constant character escape", "color: #8abeb7;"),
+          "operator" => ("operator", "color: #c5c8c6;"),
+          "diff.plus" => ("diff plus", "color: #b5bd68;"),
+          "special" => ("special", "color: #81a2be;"),
+          "markup.italic" => ("markup italic", "font-style: italic; color: #b294bb;"),
+          "background" => ("", "background-color: #1d1f21;"),
+          "markup.link.text" => ("markup link text", "color: #cc6666;"),
+          "comment" => ("comment", "font-style: italic; color: #969896;"),
+          "markup.raw" => ("markup raw", "color: #b5bd68;"),
+          "attributes" => ("attributes", "color: #de935f;"),
+          "diff.minus" => ("diff minus", "color: #cc6666;"),
+          "constructor" => ("constructor", "color: #81a2be;"),
+          "variable" => ("variable", "color: #cc6666;"),
+          "text" => ("", "color: #c5c8c6;"),
+          "constant" => ("constant", "color: #de935f;"),
+          "type" => ("type", "color: #f0c674;"),
+          "markup.heading" => ("markup heading", "color: #81a2be;"),
+          "namespace" => ("namespace", "color: #b294bb;"),
+          "markup.bold" => ("markup bold", "font-weight: bold; color: #f0c674;"),
+          "label" => ("label", "color: #b294bb;"),
           "markup.strikethrough" => ("markup strikethrough", ""),
         },
     },
@@ -4530,6 +4565,41 @@ static THEMES: phf::Map<&'static str, Theme> = phf_map! {
           "markup.strikethrough" => ("markup strikethrough", ""),
         },
     },
+    "base16_tomorrow" => Theme {
+        scopes: phf_map! {
+          "debug" => ("debug", "color: #8e908c;"),
+          "constant.numeric" => ("constant numeric", "color: #f5871f;"),
+          "function" => ("function", "color: #4271ae;"),
+          "variable.other.member" => ("variable other member", "color: #718c00;"),
+          "markup.list" => ("markup list", "color: #c82829;"),
+          "markup.quote" => ("markup quote", "color: #3e999f;"),
+          "keyword" => ("keyword", "color: #8959a8;"),
+          "diff.delta" => ("diff delta", "color: #f5871f;"),
+          "string" => ("string", "color: #718c00;"),
+          "markup.link.url" => ("markup link url", "text-decoration: underline; color: #f5871f;"),
+          "constant.character.escape" => ("constant character escape", "color: #3e999f;"),
+          "operator" => ("operator", "color: #4d4d4c;"),
+          "diff.plus" => ("diff plus", "color: #718c00;"),
+          "special" => ("special", "color: #4271ae;"),
+          "markup.italic" => ("markup italic", "font-style: italic; color: #8959a8;"),
+          "background" => ("", "background-color: #ffffff;"),
+          "markup.link.text" => ("markup link text", "color: #c82829;"),
+          "comment" => ("comment", "font-style: italic; color: #8e908c;"),
+          "markup.raw" => ("markup raw", "color: #718c00;"),
+          "attributes" => ("attributes", "color: #f5871f;"),
+          "diff.minus" => ("diff minus", "color: #c82829;"),
+          "constructor" => ("constructor", "color: #4271ae;"),
+          "variable" => ("variable", "color: #c82829;"),
+          "text" => ("", "color: #4d4d4c;"),
+          "constant" => ("constant", "color: #f5871f;"),
+          "type" => ("type", "color: #eab700;"),
+          "markup.heading" => ("markup heading", "color: #4271ae;"),
+          "namespace" => ("namespace", "color: #8959a8;"),
+          "markup.bold" => ("markup bold", "font-weight: bold; color: #eab700;"),
+          "label" => ("label", "color: #8959a8;"),
+          "markup.strikethrough" => ("markup strikethrough", ""),
+        },
+    },
     "serika_light" => Theme {
         scopes: phf_map! {
           "function" => ("function", "color: #3f4b34;"),
@@ -4866,7 +4936,7 @@ pub fn theme(name: &str) -> Option<&Theme> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    
     #[test]
     fn load_github_dark_high_contrast() {
         let _theme = theme("github_dark_high_contrast");
@@ -4922,6 +4992,10 @@ mod tests {
     #[test]
     fn load_dracula() {
         let _theme = theme("dracula");
+    }
+    #[test]
+    fn load_base16_tomorrow_night() {
+        let _theme = theme("base16_tomorrow_night");
     }
     #[test]
     fn load_zed_onedark() {
@@ -5262,6 +5336,10 @@ mod tests {
     #[test]
     fn load_gruvbox_dark_hard() {
         let _theme = theme("gruvbox_dark_hard");
+    }
+    #[test]
+    fn load_base16_tomorrow() {
+        let _theme = theme("base16_tomorrow");
     }
     #[test]
     fn load_serika_light() {

--- a/priv/themes/base16-tomorrow-night.toml
+++ b/priv/themes/base16-tomorrow-night.toml
@@ -1,0 +1,92 @@
+# Scheme name: Tomorrow Night
+# Scheme author: Chris Kempson (http://chriskempson.com)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+"attributes" = "base09"
+"comment" = { fg = "base03", modifiers = ["italic"] }
+"constant" = "base09"
+"constant.character.escape" = "base0C"
+"constant.numeric" = "base09"
+"constructor" = "base0D"
+"debug" = "base03"
+"diagnostic" = { modifiers = ["underlined"] }
+"diff.delta" = "base09"
+"diff.minus" = "base08"
+"diff.plus" = "base0B"
+"error" = "base08"
+"function" = "base0D"
+"hint" = "base03"
+"info" = "base0D"
+"keyword" = "base0E"
+"label" = "base0E"
+"namespace" = "base0E"
+"operator" = "base05"
+"special" = "base0D"
+"string"  = "base0B"
+"type" = "base0A"
+"variable" = "base08"
+"variable.other.member" = "base0B"
+"warning" = "base09"
+
+"markup.bold" = { fg = "base0A", modifiers = ["bold"] }
+"markup.heading" = "base0D"
+"markup.italic" = { fg = "base0E", modifiers = ["italic"] }
+"markup.link.text" = "base08"
+"markup.link.url" = { fg = "base09", modifiers = ["underlined"] }
+"markup.list" = "base08"
+"markup.quote" = "base0C"
+"markup.raw" = "base0B"
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+
+"diagnostic.hint" = { underline = { style = "curl" } }
+"diagnostic.info" = { underline = { style = "curl" } }
+"diagnostic.warning" = { underline = { style = "curl" } }
+"diagnostic.error" = { underline = { style = "curl" } }
+
+"ui.background" = { bg = "base00" }
+"ui.bufferline.active" = { fg = "base00", bg = "base03", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "base04", bg = "base00" }
+"ui.cursor" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor.insert" = { fg = "base0A", modifiers = ["revsered"] }
+"ui.cursorline.primary" = { fg = "base05", bg = "base01" }
+"ui.cursor.match" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor.select" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.gutter" = { bg = "base00" }
+"ui.help" = { fg = "base06", bg = "base01" }
+"ui.linenr" = { fg = "base03", bg = "base00" }
+"ui.linenr.selected" = { fg = "base04", bg = "base01", modifiers = ["bold"] }
+"ui.menu" = { fg = "base05", bg = "base01" }
+"ui.menu.scroll" = { fg = "base03", bg = "base01" }
+"ui.menu.selected" = { fg = "base01", bg = "base04" }
+"ui.popup" = { bg = "base01" }
+"ui.selection" = { bg = "base02" }
+"ui.selection.primary" = { bg = "base02" }
+"ui.statusline" = { fg = "base04", bg = "base01" }
+"ui.statusline.inactive" = { bg = "base01", fg = "base03" }
+"ui.statusline.insert" = { fg = "base00", bg = "base0B" }
+"ui.statusline.normal" = { fg = "base00", bg = "base03" }
+"ui.statusline.select" = { fg = "base00", bg = "base0F" }
+"ui.text" = "base05"
+"ui.text.focus" = "base05"
+"ui.virtual.indent-guide" = { fg = "base03" }
+"ui.virtual.inlay-hint" = { fg = "base01" }
+"ui.virtual.ruler" = { bg = "base01" }
+"ui.window" = { bg = "base01" }
+
+[palette]
+base00 = "#1d1f21" # Default Background
+base01 = "#282a2e" # Lighter Background (Used for status bars, line number and folding marks)
+base02 = "#373b41" # Selection Background
+base03 = "#969896" # Comments, Invisibles, Line Highlighting
+base04 = "#b4b7b4" # Dark Foreground (Used for status bars)
+base05 = "#c5c8c6" # Default Foreground, Caret, Delimiters, Operators
+base06 = "#e0e0e0" # Light Foreground (Not often used)
+base07 = "#ffffff" # Light Background (Not often used)
+base08 = "#cc6666" # Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+base09 = "#de935f" # Integers, Boolean, Constants, XML Attributes, Markup Link Url
+base0A = "#f0c674" # Classes, Markup Bold, Search Text Background
+base0B = "#b5bd68" # Strings, Inherited Class, Markup Code, Diff Inserted
+base0C = "#8abeb7" # Support, Regular Expressions, Escape Characters, Markup Quotes
+base0D = "#81a2be" # Functions, Methods, Attribute IDs, Headings
+base0E = "#b294bb" # Keywords, Storage, Selector, Markup Italic, Diff Changed
+base0F = "#a3685a" # Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>

--- a/priv/themes/base16-tomorrow.toml
+++ b/priv/themes/base16-tomorrow.toml
@@ -1,0 +1,92 @@
+# Scheme name: Tomorrow
+# Scheme author: Chris Kempson (http://chriskempson.com)
+# Template author: Tinted Theming (https://github.com/tinted-theming)
+
+"attributes" = "base09"
+"comment" = { fg = "base03", modifiers = ["italic"] }
+"constant" = "base09"
+"constant.character.escape" = "base0C"
+"constant.numeric" = "base09"
+"constructor" = "base0D"
+"debug" = "base03"
+"diagnostic" = { modifiers = ["underlined"] }
+"diff.delta" = "base09"
+"diff.minus" = "base08"
+"diff.plus" = "base0B"
+"error" = "base08"
+"function" = "base0D"
+"hint" = "base03"
+"info" = "base0D"
+"keyword" = "base0E"
+"label" = "base0E"
+"namespace" = "base0E"
+"operator" = "base05"
+"special" = "base0D"
+"string"  = "base0B"
+"type" = "base0A"
+"variable" = "base08"
+"variable.other.member" = "base0B"
+"warning" = "base09"
+
+"markup.bold" = { fg = "base0A", modifiers = ["bold"] }
+"markup.heading" = "base0D"
+"markup.italic" = { fg = "base0E", modifiers = ["italic"] }
+"markup.link.text" = "base08"
+"markup.link.url" = { fg = "base09", modifiers = ["underlined"] }
+"markup.list" = "base08"
+"markup.quote" = "base0C"
+"markup.raw" = "base0B"
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+
+"diagnostic.hint" = { underline = { style = "curl" } }
+"diagnostic.info" = { underline = { style = "curl" } }
+"diagnostic.warning" = { underline = { style = "curl" } }
+"diagnostic.error" = { underline = { style = "curl" } }
+
+"ui.background" = { bg = "base00" }
+"ui.bufferline.active" = { fg = "base00", bg = "base03", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "base04", bg = "base00" }
+"ui.cursor" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor.insert" = { fg = "base0A", modifiers = ["revsered"] }
+"ui.cursorline.primary" = { fg = "base05", bg = "base01" }
+"ui.cursor.match" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor.select" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.gutter" = { bg = "base00" }
+"ui.help" = { fg = "base06", bg = "base01" }
+"ui.linenr" = { fg = "base03", bg = "base00" }
+"ui.linenr.selected" = { fg = "base04", bg = "base01", modifiers = ["bold"] }
+"ui.menu" = { fg = "base05", bg = "base01" }
+"ui.menu.scroll" = { fg = "base03", bg = "base01" }
+"ui.menu.selected" = { fg = "base01", bg = "base04" }
+"ui.popup" = { bg = "base01" }
+"ui.selection" = { bg = "base02" }
+"ui.selection.primary" = { bg = "base02" }
+"ui.statusline" = { fg = "base04", bg = "base01" }
+"ui.statusline.inactive" = { bg = "base01", fg = "base03" }
+"ui.statusline.insert" = { fg = "base00", bg = "base0B" }
+"ui.statusline.normal" = { fg = "base00", bg = "base03" }
+"ui.statusline.select" = { fg = "base00", bg = "base0F" }
+"ui.text" = "base05"
+"ui.text.focus" = "base05"
+"ui.virtual.indent-guide" = { fg = "base03" }
+"ui.virtual.inlay-hint" = { fg = "base01" }
+"ui.virtual.ruler" = { bg = "base01" }
+"ui.window" = { bg = "base01" }
+
+[palette]
+base00 = "#ffffff" # Default Background
+base01 = "#e0e0e0" # Lighter Background (Used for status bars, line number and folding marks)
+base02 = "#d6d6d6" # Selection Background
+base03 = "#8e908c" # Comments, Invisibles, Line Highlighting
+base04 = "#969896" # Dark Foreground (Used for status bars)
+base05 = "#4d4d4c" # Default Foreground, Caret, Delimiters, Operators
+base06 = "#282a2e" # Light Foreground (Not often used)
+base07 = "#1d1f21" # Light Background (Not often used)
+base08 = "#c82829" # Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+base09 = "#f5871f" # Integers, Boolean, Constants, XML Attributes, Markup Link Url
+base0A = "#eab700" # Classes, Markup Bold, Search Text Background
+base0B = "#718c00" # Strings, Inherited Class, Markup Code, Diff Inserted
+base0C = "#3e999f" # Support, Regular Expressions, Escape Characters, Markup Quotes
+base0D = "#4271ae" # Functions, Methods, Attribute IDs, Headings
+base0E = "#8959a8" # Keywords, Storage, Selector, Markup Italic, Diff Changed
+base0F = "#a3685a" # Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>


### PR DESCRIPTION
Add the base16-tomorrow and base16-tomorrow_night themes, from https://github.com/tinted-theming/base16-shell.

Tomorrow Night: 
<img width="829" alt="CleanShot 2023-11-11 at 22 59 15@2x" src="https://github.com/leandrocp/autumn/assets/168193/426f87cb-7325-4bea-b86d-29236b5ef1c3">


Tomorrow
<img width="833" alt="CleanShot 2023-11-11 at 23 00 02@2x" src="https://github.com/leandrocp/autumn/assets/168193/f9b9e333-dc7f-43c3-9ce7-a9cde0eb1e41">


These screenshots were taken by (ab)using MDex builds by copying the generated themes over to their vendored Autumn.