### PR TITLE
Deprecate passing lang as first argument

### DIFF
--- a/lib/autumn.ex
+++ b/lib/autumn.ex
@@ -51,16 +51,16 @@ defmodule Autumn do
 
   ## Options
 
-  * `:language` (required) - the language to use for highlighting.
-  Besides a language name, you can also pass a filename or extension. An invalid language or `nil` will fallback to rendering plain text
-  using the background and foreground colors defined by the current theme.
-  * `:theme` (default `"onedark"`) - accepts any theme listed [here](https://github.com/leandrocp/autumn/tree/main/priv/themes).
+  * `:language` (default: `nil`) - the language to use for highlighting.
+  Besides a language name, you can also pass a filename or extension. Note that an invalid language or `nil` will fallback
+  to rendering plain text (no colors) using the background and foreground colors defined by the current theme.
+  * `:theme` (default: `"onedark"`) - accepts any theme listed [here](https://github.com/leandrocp/autumn/tree/main/priv/themes).
   You should pass the filename without special chars and without extension,
   for example pass `theme: "adwaita_dark"` to use the [Adwaita Dark](https://github.com/leandrocp/autumn/blob/main/priv/themes/adwaita-dark.toml) theme
   or `theme: "penumbra"` to use the [Penumbra+](https://github.com/leandrocp/autumn/blob/main/priv/themes/penumbra%2B.toml) theme.
-  * `:pre_class` (default `nil`) - the CSS class to inject into the wrapping parent `<pre>` tag.
+  * `:pre_class` (default: `nil`) - the CSS class to inject into the wrapping parent `<pre>` tag.
   By default it renders a `<pre>` tag with the `autumn-hl` class which will be merged with the class passed into this option.
-  * `:inline_style` (default `true`) - see more info on the module doc.
+  * `:inline_style` (default: `true`) - see more info on the module doc.
 
   ## Examples
 
@@ -84,7 +84,9 @@ defmodule Autumn do
 
   """
   @spec highlight(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
-  def highlight(source_code, opts \\ []) when is_binary(source_code) and is_list(opts) do
+  def highlight(source_code, opts \\ [])
+
+  def highlight(source_code, opts) when is_binary(source_code) and is_list(opts) do
     language = opts |> Keyword.get(:language, nil) |> language()
     theme = Keyword.get(opts, :theme, "onedark")
     pre_class = Keyword.get(opts, :pre_class, nil)
@@ -101,7 +103,9 @@ defmodule Autumn do
   Same as `highlight/2` but raises in case of failure.
   """
   @spec highlight!(String.t(), keyword()) :: String.t()
-  def highlight!(source_code, opts \\ []) do
+  def highlight!(source_code, opts \\ [])
+
+  def highlight!(source_code, opts) do
     case highlight(source_code, opts) do
       {:ok, highlighted} ->
         highlighted

--- a/lib/autumn.ex
+++ b/lib/autumn.ex
@@ -16,17 +16,44 @@ defmodule Autumn do
       - ".rs"
       - "php"
 
-  An invalid language or `nil` will fallback to rendering plain text
-  using the background and foreground colors defined by the current theme.
 
   """
   @type lang_filename_ext :: String.t() | nil
+
+  @deprecated "Use highlight/2 instead"
+  def highlight(lang_filename_ext, source_code, opts) do
+    IO.warn("""
+      passing the language in the first parameter is deprecated, pass a `:language` option instead:
+
+        Autumn.highlight("import Kernel", language: "elixir")
+
+    """)
+
+    opts = Keyword.put(opts, :language, lang_filename_ext)
+    highlight(source_code, opts)
+  end
+
+  @deprecated "Use highlight!/2 instead"
+  def highlight!(lang_filename_ext, source_code, opts) do
+    IO.warn("""
+      passing the language in the first parameter is deprecated, pass a `:language` option instead:
+
+        Autumn.highlight!("import Kernel", language: "elixir")
+
+    """)
+
+    opts = Keyword.put(opts, :language, lang_filename_ext)
+    highlight!(source_code, opts)
+  end
 
   @doc """
   Highlights the `source_code` using the tree-sitter grammar for `lang_filename_ext`.
 
   ## Options
 
+  * `:language` (required) - the language to use for highlighting.
+  Besides a language name, you can also pass a filename or extension. An invalid language or `nil` will fallback to rendering plain text
+  using the background and foreground colors defined by the current theme.
   * `:theme` (default `"onedark"`) - accepts any theme listed [here](https://github.com/leandrocp/autumn/tree/main/priv/themes).
   You should pass the filename without special chars and without extension,
   for example pass `theme: "adwaita_dark"` to use the [Adwaita Dark](https://github.com/leandrocp/autumn/blob/main/priv/themes/adwaita-dark.toml) theme
@@ -34,29 +61,54 @@ defmodule Autumn do
   * `:pre_class` (default `nil`) - the CSS class to inject into the wrapping parent `<pre>` tag.
   By default it renders a `<pre>` tag with the `autumn-hl` class which will be merged with the class passed into this option.
   * `:inline_style` (default `true`) - see more info on the module doc.
+
+  ## Examples
+
+  Passing a language name:
+
+      iex> {:ok, hl} = Autumn.highlight("Atom.to_string(:elixir)", language: "elixir")
+      iex> IO.puts(hl)
+      #=> <pre class="autumn-hl" style="background-color: #282C34; color: #ABB2BF;"><code class="language-elixir" translate="no"><span class="ahl-namespace" style="color: #61AFEF;">Atom</span><span class="ahl-operator" style="color: #C678DD;">.</span><span class="ahl-function" style="color: #61AFEF;">to_string</span><span class="ahl-punctuation ahl-bracket" style="color: #ABB2BF;">(</span><span class="ahl-string ahl-special ahl-symbol" style="color: #98C379;">:elixir</span><span class="ahl-punctuation ahl-bracket" style="color: #ABB2BF;">)</span></code></pre>
+
+  Or more options with a file extension:
+
+      iex> {:ok, hl} = Autumn.highlight("Atom.to_string(:elixir)", language: ".ex", inline_style: false, pre_class: "my-app-code")
+      iex> IO.puts(hl)
+      #=> <pre class="autumn-hl my-app-code"><code class="language-elixir" translate="no"><span class="ahl-namespace">Atom</span><span class="ahl-operator">.</span><span class="ahl-function">to_string</span><span class="ahl-punctuation ahl-bracket">(</span><span class="ahl-string ahl-special ahl-symbol">:elixir</span><span class="ahl-punctuation ahl-bracket">)</span></code></pre>
+
+  And no language results in plain text:
+
+      iex> {:ok, hl} = Autumn.highlight("Atom.to_string(:elixir)")
+      iex> IO.puts(hl)
+      #=> <pre class="autumn-hl" style="background-color: #282C34; color: #ABB2BF;"><code class="language-plaintext" translate="no">Atom.to_string(:elixir)</code></pre>
+
   """
-  @spec highlight(lang_filename_ext(), String.t(), keyword()) ::
-          {:ok, String.t()} | {:error, term()}
-  def highlight(lang_filename_ext, source_code, opts \\ []) do
-    lang = language(lang_filename_ext)
+  @spec highlight(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def highlight(source_code, opts \\ []) when is_binary(source_code) and is_list(opts) do
+    language = opts |> Keyword.get(:language, nil) |> language()
     theme = Keyword.get(opts, :theme, "onedark")
     pre_class = Keyword.get(opts, :pre_class, nil)
     inline_style = Keyword.get(opts, :inline_style, true)
-    Autumn.Native.highlight(lang, source_code, theme, pre_class, inline_style)
+    Autumn.Native.highlight(language, source_code, theme, pre_class, inline_style)
+  end
+
+  def highlight(lang_filename_ext, source_code)
+      when is_binary(lang_filename_ext) and is_binary(source_code) do
+    highlight(source_code, language: lang_filename_ext)
   end
 
   @doc """
-  Same as `highlight/3` but raises in case of failure.
+  Same as `highlight/2` but raises in case of failure.
   """
-  @spec highlight!(lang_filename_ext(), String.t(), keyword()) :: String.t()
-  def highlight!(lang_filename_ext, source_code, opts \\ []) do
-    case highlight(lang_filename_ext, source_code, opts) do
+  @spec highlight!(String.t(), keyword()) :: String.t()
+  def highlight!(source_code, opts \\ []) do
+    case highlight(source_code, opts) do
       {:ok, highlighted} ->
         highlighted
 
       {:error, error} ->
         raise """
-        failed to highlight source code for #{lang_filename_ext}
+        failed to highlight source code
 
         Got:
 
@@ -64,6 +116,11 @@ defmodule Autumn do
 
         """
     end
+  end
+
+  def highlight!(lang_filename_ext, source_code)
+      when is_binary(lang_filename_ext) and is_binary(source_code) do
+    highlight!(source_code, language: lang_filename_ext)
   end
 
   @doc false

--- a/lib/autumn.ex
+++ b/lib/autumn.ex
@@ -105,7 +105,7 @@ defmodule Autumn do
   @spec highlight!(String.t(), keyword()) :: String.t()
   def highlight!(source_code, opts \\ [])
 
-  def highlight!(source_code, opts) do
+  def highlight!(source_code, opts) when is_binary(source_code) and is_list(opts) do
     case highlight(source_code, opts) do
       {:ok, highlighted} ->
         highlighted

--- a/lib/mix/tasks/autumn.generate_samples.ex
+++ b/lib/mix/tasks/autumn.generate_samples.ex
@@ -190,7 +190,7 @@ defmodule Mix.Tasks.Autumn.GenerateSamples do
   defp do_generage_inline(lang, source, theme, style) do
     Mix.shell().info("#{lang} - #{theme} (inline)")
 
-    code = Autumn.highlight!(lang, source, theme: theme, inline_style: true)
+    code = Autumn.highlight!(source, language: lang, theme: theme, inline_style: true)
 
     html =
       EEx.eval_string(@layout_inline,
@@ -206,7 +206,7 @@ defmodule Mix.Tasks.Autumn.GenerateSamples do
   defp do_generage_css(lang, source, theme, style) do
     Mix.shell().info("#{lang} - #{theme}")
 
-    code = Autumn.highlight!(lang, source, theme: theme, inline_style: false)
+    code = Autumn.highlight!(source, language: lang, theme: theme, inline_style: false)
 
     theme_style =
       File.read!(Path.join([:code.priv_dir(:autumn), "static", "css", "#{theme}.css"]))

--- a/native/autumn/src/lib.rs
+++ b/native/autumn/src/lib.rs
@@ -74,12 +74,12 @@ pub fn open_pre_tag(theme: &Theme, class: Option<&str>, inline_style: bool) -> S
         let background_style = theme.get_global_style("background");
         let foreground_style = theme.get_global_style("foreground");
 
-        return format!(
+        format!(
             "<pre class=\"{}\" style=\"{} {}\">",
             class, background_style, foreground_style
-        );
+        )
     } else {
-        return format!("<pre class=\"{}\">", class);
+        format!("<pre class=\"{}\">", class)
     }
 }
 

--- a/test/autumn_test.exs
+++ b/test/autumn_test.exs
@@ -7,6 +7,21 @@ defmodule AutumnTest do
     assert String.trim(result) == String.trim(expected)
   end
 
+  describe "deprecated still works" do
+    test "highlight" do
+      assert {:ok, hl} = Autumn.highlight("elixir", ":elixir")
+      assert hl =~ "symbol"
+
+      assert {:ok, hl} = Autumn.highlight("elixir", ":elixir", theme: "dracula")
+      assert hl =~ "symbol"
+    end
+
+    test "highlight!" do
+      assert Autumn.highlight!("elixir", ":elixir") =~ "symbol"
+      assert Autumn.highlight!("elixir", ":elixir", theme: "dracula") =~ "symbol"
+    end
+  end
+
   describe "highlight" do
     test "elixir with default opts" do
       assert_output("elixir", ":elixir", ~s"""

--- a/test/autumn_test.exs
+++ b/test/autumn_test.exs
@@ -1,8 +1,8 @@
 defmodule AutumnTest do
   use ExUnit.Case
 
-  defp assert_output(lang, source_code, expected, opts \\ []) do
-    result = Autumn.highlight!(lang, source_code, opts)
+  defp assert_output(source_code, expected, opts \\ []) do
+    result = Autumn.highlight!(source_code, opts)
     # IO.puts(result)
     assert String.trim(result) == String.trim(expected)
   end
@@ -24,15 +24,23 @@ defmodule AutumnTest do
 
   describe "highlight" do
     test "elixir with default opts" do
-      assert_output("elixir", ":elixir", ~s"""
-      <pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-string ahl-special ahl-symbol\" style=\"color: #98C379;\">:elixir</span></code></pre>
-      """)
+      assert_output(
+        ":elixir",
+        ~s"""
+        <pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-string ahl-special ahl-symbol\" style=\"color: #98C379;\">:elixir</span></code></pre>
+        """,
+        language: "elixir"
+      )
     end
 
     test "ruby with default opts" do
-      assert_output("script.rb", ~s|puts "autumn season"|, ~s"""
-      <pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-ruby\" translate=\"no\"><span class=\"ahl-function ahl-method\" style=\"color: #61AFEF;\">puts</span> <span class=\"ahl-string\" style=\"color: #98C379;\">&quot;autumn season&quot;</span></code></pre>
-      """)
+      assert_output(
+        ~s|puts "autumn season"|,
+        ~s"""
+        <pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-ruby\" translate=\"no\"><span class=\"ahl-function ahl-method\" style=\"color: #61AFEF;\">puts</span> <span class=\"ahl-string\" style=\"color: #98C379;\">&quot;autumn season&quot;</span></code></pre>
+        """,
+        language: "script.rb"
+      )
     end
 
     test "fallback to plaintext on invalid lang" do
@@ -40,24 +48,24 @@ defmodule AutumnTest do
       <pre class="autumn-hl" style="background-color: #282C34; color: #ABB2BF;"><code class="language-plaintext" translate="no">code</code></pre>
       """
 
-      assert_output("invalid", "code", expected)
-      assert_output(nil, "code", expected)
+      assert_output("code", expected, language: "invalid")
+      assert_output("code", expected, language: nil)
     end
   end
 
   describe "theming" do
     test "invalid theme" do
-      assert Autumn.highlight("elixir", ":elixir", theme: "invalid") ==
+      assert Autumn.highlight(":elixir", language: "elixir", theme: "invalid") ==
                {:error, "unknown theme: invalid"}
     end
 
     test "change theme" do
       assert_output(
-        "elixir",
         ":elixir",
         ~s"""
         <pre class=\"autumn-hl\" style=\"background-color: #282A36; color: #f8f8f2;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-string ahl-special ahl-symbol\" style=\"color: #ffb86c;\">:elixir</span></code></pre>
         """,
+        language: "elixir",
         theme: "dracula"
       )
     end
@@ -65,58 +73,58 @@ defmodule AutumnTest do
 
   test "inject pre class" do
     assert_output(
-      "elixir",
       ":elixir",
       ~s"""
       <pre class=\"autumn-hl pre-class\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-string ahl-special ahl-symbol\" style=\"color: #98C379;\">:elixir</span></code></pre>
       """,
+      language: "elixir",
       pre_class: "pre-class"
     )
   end
 
   describe "languages" do
     test "load all languages" do
-      assert {:ok, _} = Autumn.highlight("bash", "foo")
-      assert {:ok, _} = Autumn.highlight("c", "foo")
-      assert {:ok, _} = Autumn.highlight("clojure", "foo")
-      assert {:ok, _} = Autumn.highlight("c-sharp", "foo")
-      assert {:ok, _} = Autumn.highlight("commonlisp", "foo")
-      assert {:ok, _} = Autumn.highlight("cpp", "foo")
-      assert {:ok, _} = Autumn.highlight("css", "foo")
-      assert {:ok, _} = Autumn.highlight("diff", "foo")
-      assert {:ok, _} = Autumn.highlight("dockerfile", "foo")
-      assert {:ok, _} = Autumn.highlight("elisp", "foo")
-      assert {:ok, _} = Autumn.highlight("elixir", "foo")
-      assert {:ok, _} = Autumn.highlight("erlang", "foo")
-      assert {:ok, _} = Autumn.highlight("gleam", "foo")
-      assert {:ok, _} = Autumn.highlight("go", "foo")
-      assert {:ok, _} = Autumn.highlight("haskell", "foo")
-      assert {:ok, _} = Autumn.highlight("hcl", "foo")
-      assert {:ok, _} = Autumn.highlight("heex", "foo")
-      assert {:ok, _} = Autumn.highlight("html", "foo")
-      assert {:ok, _} = Autumn.highlight("java", "foo")
-      assert {:ok, _} = Autumn.highlight("javascript", "foo")
-      assert {:ok, _} = Autumn.highlight("json", "foo")
-      assert {:ok, _} = Autumn.highlight("kotlin", "foo")
-      assert {:ok, _} = Autumn.highlight("latex", "foo")
-      assert {:ok, _} = Autumn.highlight("llvm", "foo")
-      assert {:ok, _} = Autumn.highlight("lua", "foo")
-      assert {:ok, _} = Autumn.highlight("make", "foo")
-      assert {:ok, _} = Autumn.highlight("php", "foo")
-      assert {:ok, _} = Autumn.highlight("proto", "foo")
-      assert {:ok, _} = Autumn.highlight("python", "foo")
-      assert {:ok, _} = Autumn.highlight("r", "foo")
-      assert {:ok, _} = Autumn.highlight("regex", "foo")
-      assert {:ok, _} = Autumn.highlight("ruby", "foo")
-      assert {:ok, _} = Autumn.highlight("rust", "foo")
-      assert {:ok, _} = Autumn.highlight("scala", "foo")
-      assert {:ok, _} = Autumn.highlight("scss", "foo")
-      assert {:ok, _} = Autumn.highlight("sql", "foo")
-      assert {:ok, _} = Autumn.highlight("swift", "foo")
-      assert {:ok, _} = Autumn.highlight("toml", "foo")
-      assert {:ok, _} = Autumn.highlight("typescript", "foo")
-      assert {:ok, _} = Autumn.highlight("yaml", "foo")
-      assert {:ok, _} = Autumn.highlight("zig", "foo")
+      assert {:ok, _} = Autumn.highlight("foo", language: "bash")
+      assert {:ok, _} = Autumn.highlight("foo", language: "c")
+      assert {:ok, _} = Autumn.highlight("foo", language: "clojure")
+      assert {:ok, _} = Autumn.highlight("foo", language: "c-sharp")
+      assert {:ok, _} = Autumn.highlight("foo", language: "commonlisp")
+      assert {:ok, _} = Autumn.highlight("foo", language: "cpp")
+      assert {:ok, _} = Autumn.highlight("foo", language: "css")
+      assert {:ok, _} = Autumn.highlight("foo", language: "diff")
+      assert {:ok, _} = Autumn.highlight("foo", language: "dockerfile")
+      assert {:ok, _} = Autumn.highlight("foo", language: "elisp")
+      assert {:ok, _} = Autumn.highlight("foo", language: "elixir")
+      assert {:ok, _} = Autumn.highlight("foo", language: "erlang")
+      assert {:ok, _} = Autumn.highlight("foo", language: "gleam")
+      assert {:ok, _} = Autumn.highlight("foo", language: "go")
+      assert {:ok, _} = Autumn.highlight("foo", language: "haskell")
+      assert {:ok, _} = Autumn.highlight("foo", language: "hcl")
+      assert {:ok, _} = Autumn.highlight("foo", language: "heex")
+      assert {:ok, _} = Autumn.highlight("foo", language: "html")
+      assert {:ok, _} = Autumn.highlight("foo", language: "java")
+      assert {:ok, _} = Autumn.highlight("foo", language: "javascript")
+      assert {:ok, _} = Autumn.highlight("foo", language: "json")
+      assert {:ok, _} = Autumn.highlight("foo", language: "kotlin")
+      assert {:ok, _} = Autumn.highlight("foo", language: "latex")
+      assert {:ok, _} = Autumn.highlight("foo", language: "llvm")
+      assert {:ok, _} = Autumn.highlight("foo", language: "lua")
+      assert {:ok, _} = Autumn.highlight("foo", language: "make")
+      assert {:ok, _} = Autumn.highlight("foo", language: "php")
+      assert {:ok, _} = Autumn.highlight("foo", language: "proto")
+      assert {:ok, _} = Autumn.highlight("foo", language: "python")
+      assert {:ok, _} = Autumn.highlight("foo", language: "r")
+      assert {:ok, _} = Autumn.highlight("foo", language: "regex")
+      assert {:ok, _} = Autumn.highlight("foo", language: "ruby")
+      assert {:ok, _} = Autumn.highlight("foo", language: "rust")
+      assert {:ok, _} = Autumn.highlight("foo", language: "scala")
+      assert {:ok, _} = Autumn.highlight("foo", language: "scss")
+      assert {:ok, _} = Autumn.highlight("foo", language: "sql")
+      assert {:ok, _} = Autumn.highlight("foo", language: "swift")
+      assert {:ok, _} = Autumn.highlight("foo", language: "toml")
+      assert {:ok, _} = Autumn.highlight("foo", language: "typescript")
+      assert {:ok, _} = Autumn.highlight("foo", language: "yaml")
+      assert {:ok, _} = Autumn.highlight("foo", language: "zig")
     end
 
     test "by name" do


### PR DESCRIPTION
Language is technically optional and in the future we might even be able to guess the language so passing `nil` as argument would be odd