### PR TITLE
fix: escape curly braces

### DIFF
--- a/native/autumn/src/lib.rs
+++ b/native/autumn/src/lib.rs
@@ -109,8 +109,11 @@ pub fn inner_highlights(
             let span = source
                 .get(start..end)
                 .expect("source bounds should be in bounds!");
-             let span = v_htmlescape::escape(span).to_string().replace('{', "&#123").replace('}', "&#125");
-             output.push_str(&span);
+            let span = v_htmlescape::escape(span)
+                .to_string()
+                .replace('{', "&#123")
+                .replace('}', "&#125");
+            output.push_str(&span);
         }
         HighlightEvent::HighlightStart(idx) => {
             let scope = inkjet::constants::HIGHLIGHT_NAMES[idx.0];
@@ -184,6 +187,4 @@ mod tests {
             "<pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-variable\" style=\"color: #ABB2BF;\">fun</span> <span class=\"ahl-operator\" style=\"color: #C678DD;\">=</span> <span class=\"ahl-operator\" style=\"color: #C678DD;\">&amp;</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">(</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">&#123</span><span class=\"ahl-operator\" style=\"color: #C678DD;\">&amp;</span><span class=\"ahl-operator\" style=\"color: #C678DD;\">1</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">&#125</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">)</span></code></pre>"
         );
     }
-
-
 }

--- a/native/autumn/src/lib.rs
+++ b/native/autumn/src/lib.rs
@@ -109,8 +109,8 @@ pub fn inner_highlights(
             let span = source
                 .get(start..end)
                 .expect("source bounds should be in bounds!");
-            let span = v_htmlescape::escape(span).to_string();
-            output.push_str(span.as_str())
+             let span = v_htmlescape::escape(span).to_string().replace('{', "&#123").replace('}', "&#125");
+             output.push_str(&span);
         }
         HighlightEvent::HighlightStart(idx) => {
             let scope = inkjet::constants::HIGHLIGHT_NAMES[idx.0];
@@ -173,4 +173,17 @@ mod tests {
             "<pre class=\"autumn-hl pre_class\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-rust\" translate=\"no\"><span class=\"ahl-keyword ahl-control ahl-import\" style=\"color: #E06C75;\">mod</span> <span class=\"ahl-namespace\" style=\"color: #61AFEF;\">themes</span><span class=\"ahl-punctuation ahl-delimiter\" style=\"color: #ABB2BF;\">;</span></code></pre>"
         );
     }
+
+    #[test]
+    fn test_escape() {
+        let theme = themes::theme("onedark").unwrap();
+        let output = highlight_source_code("fun = &({&1})", Language::Elixir, theme, None, true);
+
+        assert_eq!(
+            output,
+            "<pre class=\"autumn-hl\" style=\"background-color: #282C34; color: #ABB2BF;\"><code class=\"language-elixir\" translate=\"no\"><span class=\"ahl-variable\" style=\"color: #ABB2BF;\">fun</span> <span class=\"ahl-operator\" style=\"color: #C678DD;\">=</span> <span class=\"ahl-operator\" style=\"color: #C678DD;\">&amp;</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">(</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">&#123</span><span class=\"ahl-operator\" style=\"color: #C678DD;\">&amp;</span><span class=\"ahl-operator\" style=\"color: #C678DD;\">1</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">&#125</span><span class=\"ahl-punctuation ahl-bracket\" style=\"color: #ABB2BF;\">)</span></code></pre>"
+        );
+    }
+
+
 }

--- a/native/inkjet_nif/src/inline_html.rs
+++ b/native/inkjet_nif/src/inline_html.rs
@@ -26,7 +26,7 @@ impl<'a> InlineHTML<'a> {
     }
 }
 
-impl<'a> Formatter for InlineHTML<'a> {
+impl Formatter for InlineHTML<'_> {
     fn write<Write>(&self, source: &str, output: &mut Write, event: HighlightEvent) -> Result<()>
     where
         Write: std::fmt::Write,


### PR DESCRIPTION
Escape { } to avoid syntax errors on heex (phoenix liveview) templates